### PR TITLE
Fix T201 linting errors

### DIFF
--- a/backend/examples/cli_research.py
+++ b/backend/examples/cli_research.py
@@ -1,6 +1,9 @@
 import argparse
+import logging
 from langchain_core.messages import HumanMessage
 from agent.graph import graph
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -36,8 +39,9 @@ def main() -> None:
     result = graph.invoke(state)
     messages = result.get("messages", [])
     if messages:
-        print(messages[-1].content)
+        logger.info(messages[-1].content)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/backend/src/agent/app.py
+++ b/backend/src/agent/app.py
@@ -1,7 +1,10 @@
 # mypy: disable - error - code = "no-untyped-def,misc"
 import pathlib
+import logging
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
+
+logger = logging.getLogger(__name__)
 
 # Define the FastAPI app
 app = FastAPI()
@@ -19,8 +22,9 @@ def create_frontend_router(build_dir="../frontend/dist"):
     build_path = pathlib.Path(__file__).parent.parent.parent / build_dir
 
     if not build_path.is_dir() or not (build_path / "index.html").is_file():
-        print(
-            f"WARN: Frontend build directory not found or incomplete at {build_path}. Serving frontend will likely fail."
+        logger.warning(
+            "WARN: Frontend build directory not found or incomplete at %s. Serving frontend will likely fail.",
+            build_path,
         )
         # Return a dummy router if build isn't ready
         from starlette.routing import Route


### PR DESCRIPTION
## Summary
- replace `print` with logging in example script
- log a warning instead of `print` in the FastAPI app

## Testing
- `uv run ruff check --select T201 backend`

------
https://chatgpt.com/codex/tasks/task_e_68571bc48bd483228bfe6ee9ef6615f0