### PR TITLE
Fix prompts module and run install steps

### DIFF
--- a/backend/src/agent/app.py
+++ b/backend/src/agent/app.py
@@ -1,12 +1,11 @@
 """FastAPI application exposing the LangGraph agent and frontend assets."""
 
 # mypy: disable - error - code = "no-untyped-def,misc"
+import logging
 import pathlib
 
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
-
-logger = logging.getLogger(__name__)
 
 # Define the FastAPI app
 app = FastAPI()

--- a/backend/src/agent/prompts.py
+++ b/backend/src/agent/prompts.py
@@ -1,4 +1,8 @@
 from datetime import datetime
+
+
+def get_current_date() -> str:
+    """Return the current date formatted for prompts."""
     return datetime.now().strftime("%B %d, %Y")
 
 


### PR DESCRIPTION
## Summary
- fix missing `logging` import in backend app
- add a helper to get the current date in prompts

## Testing
- `make -C backend lint` *(fails: Missing docstrings)*
- `make dev` *(backend and frontend servers start)*

------
https://chatgpt.com/codex/tasks/task_e_68572aefb81c8322b2fac99e46877b47